### PR TITLE
Add PEP sponsor info to standing delegations process doc

### DIFF
--- a/process/standing-delegations.md
+++ b/process/standing-delegations.md
@@ -11,7 +11,9 @@ the [PyPA Specifications] section in the Python Packaging User Guide and the
 process for updating those specifications is documented in the [PyPA
 Documentation].
 
-These delegations are expected to stand indefinitely.
+These delegations are expected to stand indefinitely. Any of the standing
+delegates may also be a sponsor for any packaging-related PEP, regardless
+of their Python core developer status.
 
 Standing Delegations:
 


### PR DESCRIPTION
Clarify that any members of standing PyPA delegations have the power to also be PEP sponsors, regardless of their Python core developer status.

Per discussion of PEP 609 by Nick Coghlan in https://discuss.python.org/t/pep-609-pypa-governance/2619/12 and by others in https://github.com/python/peps/pull/1425 .

Signed-off-by: Sumana Harihareswara <sh@changeset.nyc>