### PR TITLE
Automate updating the README

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,19 @@
+name: Lint
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+
+      - name: Check README is up-to-date
+        run: |
+          make check

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
-# Updates the list of of "Updates" in the README
+# Updates the list of "Updates" in the README
 update:
-	cog -v > /dev/null || python3 -m pip cog
+	cog -v > /dev/null || python3 -m pip install cogapp
 	cog -Pr README.md
+
+# Check if update needed to the list of "Updates" in the README
+check:
+	cog -v > /dev/null || python3 -m pip install cogapp
+	cog -P --check README.md

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+# Updates the list of of "Updates" in the README
+update:
+	cog -v > /dev/null || python3 -m pip cog
+	cog -Pr README.md

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repo contains activity updates, process, and planning information for the P
 These updates provide high level information about the Steering Council's
 activities.
 
+- [2019-02-15](updates/2019-02-15_steering-council-update.md)
 - [2019-02-26](updates/2019-02-26_steering-council-update.md)
 - [2019-02-15](updates/2019-02-15_steering-council-update.md)
 - [2019-04-26](updates/2019-04-26_steering-council-update.md)
@@ -21,6 +22,8 @@ activities.
 - [2021-05](updates/2021-05-steering-council-update.md)
 - [2021-06](updates/2021-06-steering-council-update.md)
 - [2021-07](updates/2021-07-steering-council-update.md)
+- [2021-08](updates/2021-08-steering-council-update.md)
+- [2021-09](updates/2021-09-steering-council-update.md)
 
 ## Process
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,19 @@ This repo contains activity updates, process, and planning information for the P
 These updates provide high level information about the Steering Council's
 activities.
 
+<!-- [[[cog
+import glob
+filenames = sorted(glob.glob("updates/*steering-council-update.md"))
+for filename in filenames:
+    date = (
+        filename.removeprefix("updates/")
+        .removesuffix("steering-council-update.md")
+        .rstrip("-_")
+    )
+    print(f"- [{date}]({filename})")
+]]] -->
 - [2019-02-15](updates/2019-02-15_steering-council-update.md)
 - [2019-02-26](updates/2019-02-26_steering-council-update.md)
-- [2019-02-15](updates/2019-02-15_steering-council-update.md)
 - [2019-04-26](updates/2019-04-26_steering-council-update.md)
 - [2019-07-08](updates/2019-07-08_steering-council-update.md)
 - [2019-11-09](updates/2019-11-09-steering-council-update.md)
@@ -24,6 +34,7 @@ activities.
 - [2021-07](updates/2021-07-steering-council-update.md)
 - [2021-08](updates/2021-08-steering-council-update.md)
 - [2021-09](updates/2021-09-steering-council-update.md)
+<!-- [[[end]]] -->
 
 ## Process
 


### PR DESCRIPTION
Includes https://github.com/python/steering-council/pull/87.

Using [Ned Batchelder's cog](https://nedbatchelder.com/code/cog), we can automate updating the list of updates in the README.

It add a bit of Python code as a comment in the README, and running cog will run the Python code and update that section of the README.

```console
$ make update
cog -v > /dev/null || python3 -m pip cog
cog -Pr README.md
Cogging README.md
```

Requires Python 3.9+ as it uses `str.removeprefix` and `str.removesuffix`.

---

If you like, it'd be pretty easy to add a CI job to fail if `make update` hadn't been run. Would this be helpful?
