### PR TITLE
PyPA PEPs can be posted to Packaging

### DIFF
--- a/process/standing-delegations.md
+++ b/process/standing-delegations.md
@@ -22,3 +22,9 @@ Standing Delegations:
 
 [PyPA Specifications]: https://packaging.python.org/specifications/
 [PyPA Documentation]: https://www.pypa.io/en/latest/specifications/
+
+As an exception to the process documented in PEP 1, these PEPs should
+be announced/discussed in the [Packaging category] on Discourse,
+instead of the PEPs category.
+
+[Packaging category]: https://discuss.python.org/c/14


### PR DESCRIPTION
This formalizes existing practice (these PEPs are discussed on Discourse
instead of python-dev).
See: https://github.com/python/peps/pull/2775#discussion_r960386594

*(Edit: This is a suggestion from me to the SC, it's not yet approved by the SC.)*