### PR TITLE
PEP template: we just want a confirmation for typing PEPs

### DIFF
--- a/.github/ISSUE_TEMPLATE/pep-submission.md
+++ b/.github/ISSUE_TEMPLATE/pep-submission.md
@@ -28,7 +28,7 @@ https://peps.python.org/pep-xxxx/
   <!-- https://github.com/python/peps/blob/main/.github/CODEOWNERS -->
 
 SIG-specific:
-* [ ] *typing-sig* PEPs: link to Guido/Jelle's summary of the typing-sig discussion: 
+* [ ] *typing-sig* PEPs: link to Guido/Jelle's confirmation that the PEP captures typing-sig discussions/consensus:
 * [ ] *Packaging* PEPs: don't file the issue here, ask the delegate (Paul Moore) on [Packaging Discourse](https://discuss.python.org/c/packaging/14)
 
 <!-- Thank you for your proposal to improve Python! -->


### PR DESCRIPTION
Clarify Guido/Jelle's comment on typing PEPs should just be a quick confirmation. The PEP itself should include the kind of [summary we got for PEP 692](https://github.com/python/steering-council/issues/140#issuecomment-1247559757).

*(This is a proposal from me to the SC.)*