### PR TITLE
add Atom feed link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ This repo contains activity updates, process, and planning information for the P
 ## Updates
 
 These updates provide high level information about the Steering Council's
-activities.
+activities. [Subscribe to updates in your feedreader via the Atom 
+feed for repository commits](https://github.com/python/steering-council/commits/main.atom).
 
 <!-- [[[cog
 import glob


### PR DESCRIPTION
I used to watch this repo to ensure I got notifications of new Steering Council updates. [Then I found out I could instead subscribe via Atom.](https://stackoverflow.com/questions/7353538/setting-up-a-github-commit-rss-feed) It's not limited to the updates, but I'm happy with a syndication feed telling me of all new commits, because practically the only new commits to the the repo are meeting notes updates. I figured others might also like the link.