### PR TITLE
PEP template: Recommendation should now come from the Typing Council, not Guido/me

### DIFF
--- a/.github/ISSUE_TEMPLATE/pep-submission.md
+++ b/.github/ISSUE_TEMPLATE/pep-submission.md
@@ -28,7 +28,7 @@ https://peps.python.org/pep-xxxx/
   <!-- https://github.com/python/peps/blob/main/.github/CODEOWNERS -->
 
 SIG-specific:
-* [ ] *typing-sig* PEPs: link to Guido/Jelle's confirmation that the PEP captures typing-sig discussions/consensus:
+* [ ] *typing-sig* PEPs: link to the [Typing Council](https://github.com/python/typing-council)'s recommendation for the PEP:
 * [ ] *Packaging* PEPs: don't file the issue here, ask the delegate (Paul Moore) on [Packaging Discourse](https://discuss.python.org/c/packaging/14)
 
 <!-- Thank you for your proposal to improve Python! -->


### PR DESCRIPTION
The procedure should now be that typing PEP authors first ask the Typing Council for a recommendation, then proceed to the SC next.