### PR TITLE
PEP template: Don't mention "typing-sig"

### DIFF
--- a/.github/ISSUE_TEMPLATE/pep-submission.md
+++ b/.github/ISSUE_TEMPLATE/pep-submission.md
@@ -28,7 +28,7 @@ https://peps.python.org/pep-xxxx/
   <!-- https://github.com/python/peps/blob/main/.github/CODEOWNERS -->
 
 SIG-specific:
-* [ ] *typing-sig* PEPs: link to the [Typing Council](https://github.com/python/typing-council)'s recommendation for the PEP:
+* [ ] *Typing* PEPs: link to the [Typing Council](https://github.com/python/typing-council)'s recommendation for the PEP:
 * [ ] *Packaging* PEPs: don't file the issue here, ask the delegate (Paul Moore) on [Packaging Discourse](https://discuss.python.org/c/packaging/14)
 
 <!-- Thank you for your proposal to improve Python! -->


### PR DESCRIPTION
typing-sig was a mailing list which has now been retired.