### PR TITLE
Backlog clearing: 8 months of SC updates! 2023-11 through 2024-06-19

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ for filename in filenames:
 - [2023-08](updates/2023-08-steering-council-update.md)
 - [2023-09](updates/2023-09-steering-council-update.md)
 - [2023-10](updates/2023-10-steering-council-update.md)
+- [2023-11,12](updates/2023-11,12-steering-council-update.md)
+- [2024-01,02,03](updates/2024-01,02,03-steering-council-update.md)
+- [2024-04,05,06](updates/2024-04,05,06-steering-council-update.md)
 <!-- [[[end]]] -->
 
 ## Process

--- a/updates/2023-11,12-steering-council-update.md
+++ b/updates/2023-11,12-steering-council-update.md
@@ -1,0 +1,35 @@
+# November & December 2023 Steering Council update
+
+- Steering Council discussion topics:
+    - **PEPs**
+        - Confirmed our agreement to accept [PEP 702 deprecations in the type system](https://peps.python.org/pep-0702/).
+        - Discussed our first impressions of [PEP 712 dataclasses converters](https://peps.python.org/pep-0712/). Decided to seek more consensus. [We announced this PEP 712 feeling on discuss](https://discuss.python.org/t/pep-712-adding-a-converter-parameter-to-dataclasses-field/26126/57).
+        - Discussed, read up on, and accepted [PEP 729 Typing Governance](https://peps.python.org/pep-0729/).
+        - Discussed, read up on, and accepted [PEP 731 C API Working Group](https://peps.python.org/pep-0731/).
+        - Briefly discussed [PEP 726 module level `__setattr__` and `__delattr__`](https://peps.python.org/pep-0726/). We expect the 2024 SC to decide. *(editors note: It was rejected)*
+        - Discussed [PEP-703 making the global interpreter lock optional](https://peps.python.org/pep-0703/) naming and a desire to avoid putting negatives on the desired-to-be-legacy GIL term, thus "free-threading" rather than "nogil".
+        - Discussed and accepted [PEP 730 iOS platform support](https://peps.python.org/pep-0730/).
+        - Discussed and accepted [PEP 732 documentation editorial board](https://peps.python.org/pep-0732/).
+    - Accepting Meta’s offer to host the core dev sprints in Washington in September 2024.
+    - The proposal for mentoring resources and how to gauge interest. Coordinated with the PSF for budget and a contract to make it happen.
+    - C API issues regarding removal of some APIs and potential conflicting goals.
+    - The status of our Supporting Developer in Residence contract.
+    - The status of woefully delayed monthly updates.
+    - That we have varying workflows and communication levels of different Working Groups (WGs) and if there are potential issues arising from that.
+    - That we needed to draft an official policy around "python" and "cpython" organizations on PyPI.
+    - Establishing a communication channel with all of our Developer in Residences.
+    - The possibility of encouraging more devguide entries about how the Tier 2 interpreter in `ceval.c` works.
+    - Ongoing research into state of the world around an OS “Fetch URL” API and if those could simplify bundled `pip` requirements.
+    - The in progress SC election process.
+- Sync-ups with Łukasz (Senior Developer in Residence), topics covered included:
+    - Recent work on coverage mode and a multi-line REPL.
+    - If there are potential for alternatives to Buildbot.
+    - The status of [PEP 649 deferred evaluation of annotations,](https://peps.python.org/pep-0649/) implementation(s).
+    - The successful start of [our Supporting Developer in Residence, Serhiy Storchaka](https://discuss.python.org/t/welcoming-the-supporting-developer-in-residence/39702).
+    - The ongoing ARM performance benchmarking efforts with donated hardware. Including the renaming branch `master` to `main` while maintaining historical data requiring work.
+    - The status of two factor authentication (2FA) vs GitHub bots and the assurance that there won't be any issues with the current bots when 2FA is rolled out.
+    - The decision to drop running BigMem buildbot on 3.12 and only run on `main`. This allows Łukasz to use existing hardware.
+    - Łukasz's recent public appearances: Nokia C++ conference talk about async generators & a podcast episode about frame optimization.
+- End of term hand over meeting from [the 2023 SC](https://discuss.python.org/t/2023-term-python-steering-council-election-results/21951) to [the 2024 SC](https://discuss.python.org/t/steering-council-election-results-2024-term/40851):
+    - Goodbye Brett, Welcome Barry!
+    - Discussed our current processes.

--- a/updates/2024-01,02,03-steering-council-update.md
+++ b/updates/2024-01,02,03-steering-council-update.md
@@ -56,7 +56,7 @@
     - An update from the PSF on the status of sponsorships and future needs.
     - The desire for a better understanding of PyPI's operating costs (from the PSF) and a desire for a roadmap to facilitate better support and sponsorship.
     - Deb, PSF executive director, channelling the Python users' vibe from many angles around packaging ecosystem not being great on many fronts based on different needs and what could be done by whom.
-    - Discussed a past banned Core Dev who's 1-year ban had expired and automatically reinstated some access (an identified process issue). We reinstated that ban after they unfortunately generated fresh conduct complaints and reached out directly seeking the required acknowledgement of the code of conduct and promise to abide by it if they wanted the ban lifted.
+    - Discussed a past banned Core Dev whose 1-year ban had expired and automatically reinstated some access (an identified process issue). We reinstated that ban after they unfortunately generated fresh conduct complaints and reached out directly seeking the required acknowledgement of the code of conduct and promise to abide by it if they wanted the ban lifted.
     - Ongoing discussions of some other observed and casually reported core developer behaviors and how to foster improvement.
     - Discussed needs for better communication between PyPI and the PyPA and how to foster that.
     - Discussed with current release managers who the next release manager should be.

--- a/updates/2024-01,02,03-steering-council-update.md
+++ b/updates/2024-01,02,03-steering-council-update.md
@@ -37,7 +37,7 @@
         - The importance of transparency and good communication for the health of the community.
         - Ongoing [PEP 541 Package Index Name Retention](https://peps.python.org/pep-0541/) work.
         - The status of [PEP 649 deferred eval of annotations](https://peps.python.org/pep-0649/).
-        - Community misconceptions revealed when when talking at a small conference about our upcoming Python 3.13.
+        - Community misconceptions revealed when talking at a small conference about our upcoming Python 3.13.
         - The PyCon 2024 US language summit logistics.
         - The need to provide feedback to our DiRs.
     - More thoughts on what we want our PyPI org policy to be.

--- a/updates/2024-01,02,03-steering-council-update.md
+++ b/updates/2024-01,02,03-steering-council-update.md
@@ -8,7 +8,7 @@
         - At least 20 people applied!
         - Interviewed N candidates, rejected the others. Made a choice and sent a job offer.
         - *Editors note: Our initial job. req. described this role as "Secretary". We all agreed that role title was not great and settled upon a much more appropriate title of "Communications Liaison" with the individual hired.*
-    - Pablo coordinating with Edward for our core dev. mentorship training sessions.
+    - Pablo coordinating with Edward for our core dev mentorship training sessions.
         - The first mentoring session happened in March. Observation: We *also* used the first one as experience sharing talk time. Note to future selves: We could set our own mini-sessions up just for that.
     - Lack of use of our SC Office Hours slot and the need to better promote those.
     - **PEPs**

--- a/updates/2024-01,02,03-steering-council-update.md
+++ b/updates/2024-01,02,03-steering-council-update.md
@@ -44,7 +44,7 @@
     - Chatting with Itamar regarding Meta's September 2024 core dev sprint logistics and PSF finance details.
     - Release Management automation and contingency plan ideas.
     - The potential formation of a Packaging Council.
-    - Tier support for WASI or WASM and updating PEP-11 to reflect that.
+    - Tier support for WASI or WASM and updating [PEP 11](https://peps.python.org/pep-0011/) to reflect that.
     - Our desire to see the JIT have an informational PEP.
         - Brandt joined us for office hours to discuss this.
         - A desire for to explain what maintaining and testing entails for fellow core devs.

--- a/updates/2024-01,02,03-steering-council-update.md
+++ b/updates/2024-01,02,03-steering-council-update.md
@@ -1,0 +1,63 @@
+# January through March 2024 SC update
+
+- Steering Council (new 2024 edition) discussion topics:
+    - Discussed our current meeting time, dev in res sync times, and office hours scheduling.
+    - Hiring a part time person for note taking and what our expectations for this role should be.
+        - Drafted and posted [our official job description](https://discuss.python.org/t/the-steering-council-is-hiring/44686).
+        - Collected job applications and reviewed resumes.
+        - At least 20 people applied!
+        - Interviewed N candidates, rejected the others. Made a choice and sent a job offer.
+        - *Editors note: Our initial job. req. described this role as "Secretary". We all agreed that role title was not great and settled upon a much more appropriate title of "Communications Liaison" with the individual hired.*
+    - Pablo coordinating with Edward for our core dev. mentorship training sessions.
+        - The first mentoring session happened in March. Observation: We *also* used the first one as experience sharing talk time. Note to future selves: We could set our own mini-sessions up just for that.
+    - Lack of use of our SC Office Hours slot and the need to better promote those.
+    - **PEPs**
+        - Rejected [PEP 726 module `__setattr__` and `__delattr__`](https://peps.python.org/pep-0726/) after reviewing it and the resulting discussions. Drafted and posted the pronouncement.
+        - Discussed Windows free-threaded [PEP-703](https://peps.python.org/pep-0703/) installer design details.
+        - Many discussions on [PEP 712 dataclass converters](https://peps.python.org/pep-0712/). *(editors note: ultimately rejected)*.
+        - Accepted [PEP 737 C API to format a types fully qualified name](https://peps.python.org/pep-0737/) after much discussion; including raising [a concern about a name choice and overall scope](https://discuss.python.org/t/pep-737-unify-type-name-formatting/39872/51).
+        - Accepted [PEP 705 TypedDict: Read-only items](https://peps.python.org/pep-0705/) per the Typing Council's recommendation.
+        - Accepted [PEP 738 Adding Android as a supported platform](https://peps.python.org/pep-0738/), this spawned some discussions of CI and buildbot needs.
+        - Discussed [PEP 734 Multiple interpreters in the stdlib](https://peps.python.org/pep-0734/) and decided [to Defer it, seeking external maintenance as a PyPI module](https://discuss.python.org/t/pep-734-multiple-interpreters-in-the-stdlib/41147/24) for starters.
+            - Eric Snow joined us for office hours on this.
+        - Accepted [PEP 742 narrowing types with TypeIs](https://peps.python.org/pep-0742/) after review based on the Typing Council's recommendation.
+        - Discussions around [PEP 741 Python Configuration C API](https://peps.python.org/pep-0741/).
+        - Further discussions on [PEP 667 Consistent views of namespaces](https://peps.python.org/pep-0667/).
+    - Sync up meetings with Łukasz, the Developer-in-Residence:
+        - Recent travels and work on the PyCon US program committee.
+        - The start of our new Deputy Developer in Residence, Petr, and planning for the DiR team's focus areas.
+        - How reporting of overall DiR activity, progress, and blockers should be done.
+        - The status of two factor authentication requirements on GitHub.
+        - Logistics of our ability to implement *required* code reviews on new-feature PRs. We have a long term desire to see this for all PRs, but need to prove to core devs that it can work on a smaller uncontroverisal scale first.
+        - Future Release Manager (RM) role planning.
+        - Buildbots and their maintenance issues.
+        - The upgrade of speed.python.org.
+        - Security releases and challenges with 3.8, 3.9, & 3.10.
+        - Challenges and concerns around PyPI's account recovery process and the impact on sponsors and the community. *(editors note: The PSF has since hired someone to help with this!)*
+        - The importance of transparency and good communication for the health of the community.
+        - Ongoing [PEP 541 Package Index Name Retention](https://peps.python.org/pep-0541/) work.
+        - The status of [PEP 649 deferred eval of annotations](https://peps.python.org/pep-0649/).
+        - Community misconceptions revealed when when talking at a small conference about our upcoming Python 3.13.
+        - The PyCon 2024 US language summit logistics.
+        - The need to provide feedback to our DiRs.
+    - More thoughts on what we want our PyPI org policy to be.
+    - Chatting with Itamar regarding Meta's September 2024 core dev sprint logistics and PSF finance details.
+    - Release Management automation and contingency plan ideas.
+    - The potential formation of a Packaging Council.
+    - Tier support for WASI or WASM and updating PEP-11 to reflect that.
+    - Our desire to see the JIT have an informational PEP.
+        - Brandt joined us for office hours to discuss this.
+        - A desire for to explain what maintaining and testing entails for fellow core devs.
+        - Result: [PEP 744 JIT Compilation](https://peps.python.org/pep-0744/).
+        - Discussions of where it could head in the future and the need to do those in public forums.
+        - Experimental exit criteria, debugging, profiling, etc.
+    - Started discussing what we should focus on in our PyCon US 2024 keynote slot.
+    - A potential need to make role boundaries more clear between our different groups such as core devs, developers in residence, and release managers. Responsibility becomes more complex as we grow and mix volunteers with paid staff.
+    - An update from the PSF on the status of sponsorships and future needs.
+    - The desire for a better understanding of PyPI's operating costs (from the PSF) and a desire for a roadmap to facilitate better support and sponsorship.
+    - Deb, PSF executive director, channelling the Python users vibe from many angles around packaging ecosystem not being great on many fronts based on different needs and what could be done by whom.
+    - Discussed a past banned Core Dev who's 1-year ban had expired and automatically reinstated some access (an identified process issue). We reinstated that ban after they unfortunately generated fresh conduct complaints and reached out directly seeking the required acknowledgement of the code of conduct and promise to abide by it if they wanted the ban lifted.
+    - Ongoing discussions of some other observed and casually reported core developer behaviors and how to foster improvement.
+    - Discussed needs for better communication between PyPI and the PyPA and how to foster that.
+    - Discussed with current release managers who the next release manager should be.
+    - Approved the creation of a /python/blurb/ GitHub repo.

--- a/updates/2024-01,02,03-steering-council-update.md
+++ b/updates/2024-01,02,03-steering-council-update.md
@@ -13,7 +13,7 @@
     - Lack of use of our SC Office Hours slot and the need to better promote those.
     - **PEPs**
         - Rejected [PEP 726 module `__setattr__` and `__delattr__`](https://peps.python.org/pep-0726/) after reviewing it and the resulting discussions. Drafted and posted the pronouncement.
-        - Discussed Windows free-threaded [PEP-703](https://peps.python.org/pep-0703/) installer design details.
+        - Discussed Windows free-threaded [PEP 703](https://peps.python.org/pep-0703/) installer design details.
         - Many discussions on [PEP 712 dataclass converters](https://peps.python.org/pep-0712/). *(editors note: ultimately rejected)*.
         - Accepted [PEP 737 C API to format a types fully qualified name](https://peps.python.org/pep-0737/) after much discussion; including raising [a concern about a name choice and overall scope](https://discuss.python.org/t/pep-737-unify-type-name-formatting/39872/51).
         - Accepted [PEP 705 TypedDict: Read-only items](https://peps.python.org/pep-0705/) per the Typing Council's recommendation.

--- a/updates/2024-01,02,03-steering-council-update.md
+++ b/updates/2024-01,02,03-steering-council-update.md
@@ -55,7 +55,7 @@
     - A potential need to make role boundaries more clear between our different groups such as core devs, developers in residence, and release managers. Responsibility becomes more complex as we grow and mix volunteers with paid staff.
     - An update from the PSF on the status of sponsorships and future needs.
     - The desire for a better understanding of PyPI's operating costs (from the PSF) and a desire for a roadmap to facilitate better support and sponsorship.
-    - Deb, PSF executive director, channelling the Python users vibe from many angles around packaging ecosystem not being great on many fronts based on different needs and what could be done by whom.
+    - Deb, PSF executive director, channelling the Python users' vibe from many angles around packaging ecosystem not being great on many fronts based on different needs and what could be done by whom.
     - Discussed a past banned Core Dev who's 1-year ban had expired and automatically reinstated some access (an identified process issue). We reinstated that ban after they unfortunately generated fresh conduct complaints and reached out directly seeking the required acknowledgement of the code of conduct and promise to abide by it if they wanted the ban lifted.
     - Ongoing discussions of some other observed and casually reported core developer behaviors and how to foster improvement.
     - Discussed needs for better communication between PyPI and the PyPA and how to foster that.

--- a/updates/2024-04,05,06-steering-council-update.md
+++ b/updates/2024-04,05,06-steering-council-update.md
@@ -35,7 +35,7 @@
     - Discussed and announced who would be our next Release Manager (RM) and related logistical issues.
     - Continual brainstorming on what to include in what form for our PyCon US 2024 keynote address. In classic PyCon fashion our collective presentation was congealing up until the day we gave it.
     - Discussed a PR brought to our attention that we believe should not have been merged as is, regardless of intent, and whether or not we can do anything about it right now.
-    - More discussions community friction regarding Packaging and PyPI, the Packaging WG, and PyPA with the PSF.
+    - More discussions on community friction regarding Packaging and PyPI, the Packaging WG, and PyPA with the PSF.
     - Noticing how we have misaligned cadences among many of our collective core dev working styles. It leads to a strain on decision making. Perhaps a discussion topic for the core dev sprint at Meta?
     - Greg and Barry employer changes; no [PEP-13 conflicts](https://peps.python.org/pep-0013/#conflicts-of-interest).
     - Office hours visit from Carol Willing to discuss inclusion in our community. Rationale behind the impacts, challenges, differing burdens, and ideas for possible next steps. Some of which also align with ideas the PSF has been pondering. Lots of food for thought. Nothing is simple or quick.

--- a/updates/2024-04,05,06-steering-council-update.md
+++ b/updates/2024-04,05,06-steering-council-update.md
@@ -37,6 +37,6 @@
     - Discussed a PR brought to our attention that we believe should not have been merged as is, regardless of intent, and whether or not we can do anything about it right now.
     - More discussions on community friction regarding Packaging and PyPI, the Packaging WG, and PyPA with the PSF.
     - Noticing how we have misaligned cadences among many of our collective core dev working styles. It leads to a strain on decision making. Perhaps a discussion topic for the core dev sprint at Meta?
-    - Greg and Barry employer changes; no [PEP-13 conflicts](https://peps.python.org/pep-0013/#conflicts-of-interest).
+    - Greg and Barry employer changes; no [PEP 13 conflicts](https://peps.python.org/pep-0013/#conflicts-of-interest).
     - Office hours visit from Carol Willing to discuss inclusion in our community. Rationale behind the impacts, challenges, differing burdens, and ideas for possible next steps. Some of which also align with ideas the PSF has been pondering. Lots of food for thought. Nothing is simple or quick.
     - Started discussing a proposed PSF grant that could potentially be used to help grow early-career folks? Information being gathered.

--- a/updates/2024-04,05,06-steering-council-update.md
+++ b/updates/2024-04,05,06-steering-council-update.md
@@ -7,7 +7,7 @@
         - Finalized and posted our decision on [PEP 734, subinterpreters in the stdlib](https://discuss.python.org/t/pep-734-multiple-interpreters-in-the-stdlib/41147/24).
         - Accepted [PEP 667, Consistent views of namespaces](https://peps.python.org/pep-0667/) after much discussion. The alternatives were considered worse in the long run.
     - Sync up meetings with Łukasz, the Developer-in-Residence:
-        - The untangling of potential license and CLA issues on the infrastructure repositories. Not glamourous work, needs doing, will involve PSF council as appropriate.
+        - The untangling of potential license and CLA issues on the infrastructure repositories. Not glamorous work, needs doing, will involve PSF counsel as appropriate.
         - Discussed the fall core dev sprint Meta and PSF sponsorship status.
         - PyCon US 2024 language summit signs up at capacity.
         - Ł is going to EuroPython: Landed a keynote slot.

--- a/updates/2024-04,05,06-steering-council-update.md
+++ b/updates/2024-04,05,06-steering-council-update.md
@@ -1,0 +1,42 @@
+# April through June 19, 2024 Steering Council update
+
+- Steering Council discussion topics:
+    - **PEPs**
+        - Ongoing [PEP 741, a Configuration C API](https://peps.python.org/pep-0741/) discussions; seeking consensus and clarity and WG input. Ultimately decided to postpone this until 3.14.
+        - Repeated check-ins on [PEP 649, deferred evaluation of annotations using descriptors](https://peps.python.org/pep-0649/) implementation. We're collectively okay if this slips into 3.14.
+        - Finalized and posted our decision on [PEP 734, subinterpreters in the stdlib](https://discuss.python.org/t/pep-734-multiple-interpreters-in-the-stdlib/41147/24).
+        - Accepted [PEP 667, Consistent views of namespaces](https://peps.python.org/pep-0667/) after much discussion. The alternatives were considered worse in the long run.
+    - Sync up meetings with Łukasz, the Developer-in-Residence:
+        - The untangling of potential license and CLA issues on the infrastructure repositories. Not glamourous work, needs doing, will involve PSF council as appropriate.
+        - Discussed the fall core dev sprint Meta and PSF sponsorship status.
+        - PyCon US 2024 language summit signs up at capacity.
+        - Ł is going to EuroPython: Landed a keynote slot.
+        - Regarding the PyCon US Language Summit: Noted feedback on masking policy vs being able to hear presenters, present, and speak clearly. We follow the conference policy. Polite reminders are deemed useful.
+        - Ł and Pablo discussed encouraging people to make useful contributions to open source.
+        - Discussed buildbot config issues & speed.python.org updates.
+        - Discussed a growing TODO list of things desiring work and which of those should be delegated.
+        - Observations of potential (mis)uses of discuss.python.org as a symptom of people seeking attention on filed issues.
+        - 3.13 Beta 1 draws near (feature freeze). Preparing a last minute new REPL to land, based on PyPy's. Many edge case bugs revealed on many platforms by this.
+        - Happy to hear that PSF infrastructure hiring is in progress.
+        - Discussed Łukasz' potential mentoring of someone.
+        - Discussed too many hats being worn on interrupt driven roles leading to burnout.
+        - Discussed feedback about the the language summit and whether or not there is anything we could do in the future that wouldn't just be alternately perceived poorly as a burden.
+        - Discussed a conduct issue reported at our PyCon US 2024 core dev sprint and what we can do to make a proper welcoming environment at future events. Popularity, limited space, lack of organization, differing unaligned expectations, and biased invalid assumptions culminated in problems this year. :(
+    - Recommendation letters needed for some core dev travel Visas; being drafted. Can come from the PSF if helpful.
+    - Discussions around our Communications Liaison hiring. PSF working out the contract. Our initial offer fell through, we [extended an offer to our alternate equally qualified candidate](https://discuss.python.org/t/the-steering-council-is-hiring/44686/6), as we had discussed might happen with them during our initial rejection communication. The title was renamed from Secretary to Communications Liaison to better reflect the role.
+    - Discussed how it'd be nice if our monthly SC update summaries were actually created, reviewed, and published before PyCon US 2024. *(editors note: LOL... given the backlog this is being posted as part of, volunteer time is precious, thus hiring)*
+    - Discussed new 3.13 REPL platform implementation woes. "At least it is not using readline" also means "people who rely on obscure readline featureitis frown".
+    - Discussions of type annotations in the stdlib. More community discussions needed before any proposal can be made. Annotations in `Tools/` have found actual bugs.
+    - Discussed capacity issues at the upcoming September core dev sprint; space limitations are real and lead to hard choices.
+    - Discussed logistics of the remaining two core dev. mentorship sessions that Edward is holding this quarter. *(editors note: held)*
+    - Discussed further ongoing core dev mentorship needs and the utility of a possible Mentorship WG. One theme has always been lack of volunteer time availability.
+    - Discussed how it'd be good if release managers wrote up retrospectives. That requires extra time committment on their part. We'd all benefit, not just future RMs.
+    - Discussed our recent core dev promotion votes. No vetoes (all approved). We're noticing that our process feels a bit odd, the SC represents the community thus a veto of any form would not be well received. Nor would a vote itself failing. So this means anyone proposing someone effectively needs to do homework and talk via backchannels to a slew of core devs and SC first to ensure that neither negative outcome is likely. Maybe this is working as intended? But we don't state it as such anywhere... But what would be meaningfully better to propose?
+    - Discussed and announced who would be our next Release Manager (RM) and related logistical issues.
+    - Continual brainstorming on what to include in what form for our PyCon US 2024 keynote address. In classic PyCon fashion our collective presentation was congealing up until the day we gave it.
+    - Discussed a PR brought to our attention that we believe should not have been merged as is, regardless of intent, and whether or not we can do anything about it right now.
+    - More discussions community friction regarding Packaging and PyPI, the Packaging WG, and PyPA with the PSF.
+    - Noticing how we have misaligned cadences among many of our collective core dev working styles. It leads to a strain on decision making. Perhaps a discussion topic for the core dev sprint at Meta?
+    - Greg and Barry employer changes; no [PEP-13 conflicts](https://peps.python.org/pep-0013/#conflicts-of-interest).
+    - Office hours visit from Carol Willing to discuss inclusion in our community. Rationale behind the impacts, challenges, differing burdens, and ideas for possible next steps. Some of which also align with ideas the PSF has been pondering. Lots of food for thought. Nothing is simple or quick.
+    - Started discussing a proposed PSF grant that could potentially be used to help grow early-career folks? Information being gathered.

--- a/updates/2024-04,05,06-steering-council-update.md
+++ b/updates/2024-04,05,06-steering-council-update.md
@@ -28,7 +28,7 @@
     - Discussed new 3.13 REPL platform implementation woes. "At least it is not using readline" also means "people who rely on obscure readline featureitis frown".
     - Discussions of type annotations in the stdlib. More community discussions needed before any proposal can be made. Annotations in `Tools/` have found actual bugs.
     - Discussed capacity issues at the upcoming September core dev sprint; space limitations are real and lead to hard choices.
-    - Discussed logistics of the remaining two core dev. mentorship sessions that Edward is holding this quarter. *(editors note: held)*
+    - Discussed logistics of the remaining two core dev mentorship sessions that Edward is holding this quarter. *(editors note: held)*
     - Discussed further ongoing core dev mentorship needs and the utility of a possible Mentorship WG. One theme has always been lack of volunteer time availability.
     - Discussed how it'd be good if release managers wrote up retrospectives. That requires extra time commitment on their part. We'd all benefit, not just future RMs.
     - Discussed our recent core dev promotion votes. No vetoes (all approved). We're noticing that our process feels a bit odd, the SC represents the community thus a veto of any form would not be well received. Nor would a vote itself failing. So this means anyone proposing someone effectively needs to do homework and talk via backchannels to a slew of core devs and SC first to ensure that neither negative outcome is likely. Maybe this is working as intended? But we don't state it as such anywhere... But what would be meaningfully better to propose?

--- a/updates/2024-04,05,06-steering-council-update.md
+++ b/updates/2024-04,05,06-steering-council-update.md
@@ -30,7 +30,7 @@
     - Discussed capacity issues at the upcoming September core dev sprint; space limitations are real and lead to hard choices.
     - Discussed logistics of the remaining two core dev. mentorship sessions that Edward is holding this quarter. *(editors note: held)*
     - Discussed further ongoing core dev mentorship needs and the utility of a possible Mentorship WG. One theme has always been lack of volunteer time availability.
-    - Discussed how it'd be good if release managers wrote up retrospectives. That requires extra time committment on their part. We'd all benefit, not just future RMs.
+    - Discussed how it'd be good if release managers wrote up retrospectives. That requires extra time commitment on their part. We'd all benefit, not just future RMs.
     - Discussed our recent core dev promotion votes. No vetoes (all approved). We're noticing that our process feels a bit odd, the SC represents the community thus a veto of any form would not be well received. Nor would a vote itself failing. So this means anyone proposing someone effectively needs to do homework and talk via backchannels to a slew of core devs and SC first to ensure that neither negative outcome is likely. Maybe this is working as intended? But we don't state it as such anywhere... But what would be meaningfully better to propose?
     - Discussed and announced who would be our next Release Manager (RM) and related logistical issues.
     - Continual brainstorming on what to include in what form for our PyCon US 2024 keynote address. In classic PyCon fashion our collective presentation was congealing up until the day we gave it.


### PR DESCRIPTION
Keep in mind that most of these are "historical" at this point.  I grouped them roughly into "quarters" and tried to coalesce things within those to keep them shorter. In older notes, some of the things mentioned may have been resolved in future sessions.

Notes after these will be posted by our new PSF communications liaison.