### PR TITLE
Update standing delegations for Typing WG, C API WG, Editorial Board.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ future Steering Council members.
 
 - [Onboarding new members](process/onboarding.md)
 - [Best practices for effective governance](process/best-practices.md)
+- [Standing Delegations](process/standing-delegations.md)
 
 ## Reference
 

--- a/process/standing-delegations.md
+++ b/process/standing-delegations.md
@@ -1,8 +1,8 @@
 # Standing Delegations
 
-This document serves as a public record of current standing delegations, the
-reasons they were put in place, and the circumstances under which they may no
-longer be needed.
+This document serves as a public record of current standing delegations for
+PEPs and other areas of authority, the reasons they were put in place, and
+the circumstances under which they may no longer be needed.
 
 ## PyPA Delegations
 
@@ -15,7 +15,7 @@ These delegations are expected to stand indefinitely. Any of the standing
 delegates may also be a sponsor for any packaging-related PEP, regardless
 of their Python core developer status.
 
-Standing Delegations:
+Standing PEP Delegations:
 
 - Package Distribution Metadata PEPs: Paul Moore
 - Package Index Interface PEPs: Donald Stufft
@@ -28,3 +28,31 @@ be announced/discussed in the [Packaging category] on Discourse,
 instead of the PEPs category.
 
 [Packaging category]: https://discuss.python.org/c/14
+
+## Typing Council
+
+The Typing Council, set up in [PEP 729](https://peps.python.org/pep-0729/),
+oversees Python's type checking ecosystem as a whole. Typing PEPs are still
+accepted or rejected by the Steering Council, but only after consultation
+with the Typing Council, and typing-specific PEPs are expected to be sent to
+the Typing Council first.
+
+## C API Working Group
+
+The C API Working Group (created by and defined in [PEP
+731](https://peps.python.org/pep-0731/)) is a small committee of Python core
+developers responsible for overseeing and coordinating the development and
+maintenance of the Python C API. The Steering Council has in principle
+delegated all C API design and implementation decisions to the C API WG,
+although there is no standing PEP delegation (since the C API is rarely an
+isolated PEP topic).
+
+## Documentation Editorial Board
+
+The Documentation Editorial Board (described in [PEP
+732](https://peps.python.org/pep-0732/) is in charge of the strategy,
+structure, style and governance of all of Python's user-facing documentation
+efforts. As with the C API WG there is no standing PEP delegation as there are
+few PEPs specific to the documentation efforts, but the Editorial Board has
+specific autonomy and authority as described in PEP 732.
+


### PR DESCRIPTION
Add the Typing Council, C API WG and Documentation Editorial Board to the standing delegations doc.
